### PR TITLE
Lineage: Revert "ipsec: Fix aborted xfrm policy dump crash"

### DIFF
--- a/net/xfrm/xfrm_user.c
+++ b/net/xfrm/xfrm_user.c
@@ -1562,8 +1562,7 @@ static int xfrm_dump_policy_done(struct netlink_callback *cb)
 {
 	struct xfrm_policy_walk *walk = (struct xfrm_policy_walk *)cb->args;
 
-	if (cb->args[0])
-		xfrm_policy_walk_done(walk);
+	xfrm_policy_walk_done(walk);
 	return 0;
 }
 


### PR DESCRIPTION
This has been fixed by 210342 and 210341.

This reverts commit ea4d8a74da32cf614d25d17ada8121a43e2090ad.

Change-Id: I64a885195ce938aae0ee00e0abe265c8dd8d09f5